### PR TITLE
Fix consistency between C++/Rust reset_device() examples in 'inherita…

### DIFF
--- a/src/idioms/data_modeling/inheritance_and_reuse.md
+++ b/src/idioms/data_modeling/inheritance_and_reuse.md
@@ -56,8 +56,8 @@ trait Device {
 
     fn reset_device(&mut self) {
         println!("Resetting device...");
-        self.power_on();
         self.power_off();
+        self.power_on();
     }
 }
 


### PR DESCRIPTION
…nce and implementation reuse' section

reset_device() had the wrong order of method calls