### PR TITLE
Fix code errors, typos, and grammar across 19 files

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -45,7 +45,7 @@
 - [Rust and C++ interoperability (FFI)](./idioms/ffi.md)
 - [NRVO and RVO](./idioms/rvo.md)
 - [Placement new](./idioms/placement_new.md)
-- [Concurrency (threads and async)]()
+- Concurrency (threads and async)
 
 # Patterns
 

--- a/src/etc/build_systems.md
+++ b/src/etc/build_systems.md
@@ -6,7 +6,7 @@ repository for a project, while Rust has a central language-specific package
 registry called [crates.io](https://crates.io/).
 
 This difference is amplified by the fact that the Rust build tool, Cargo, has a
-build in package manager that works with crates.io, private registries, local
+built-in package manager that works with crates.io, private registries, local
 packages, and vendored sources.
 
 Cargo is documented in detail in the [Cargo

--- a/src/idioms/data_modeling/abstract_classes.md
+++ b/src/idioms/data_modeling/abstract_classes.md
@@ -165,7 +165,7 @@ given by a user defined `Drop` implementation or not) required for the value.
 
 ## Vtables and Rust trait object types
 
-C++ and Rust both requires some kind of indirection to perform dynamic dispatch
+C++ and Rust both require some kind of indirection to perform dynamic dispatch
 against an interface. In C++ this indirection takes the form of a pointer to the
 abstract class (instead of the derived concrete class), making use of a vtable
 to resolve the virtual method.

--- a/src/idioms/data_modeling/inheritance_and_reuse.md
+++ b/src/idioms/data_modeling/inheritance_and_reuse.md
@@ -100,7 +100,7 @@ dispatch](./concepts.md) (with [no vtable overhead in the
 static dispatch
 case](./abstract_classes.md#vtables-and-rust-trait-object-types)).
 
-Rust traits differ from abstract classes in few more ways. For example,
+Rust traits differ from abstract classes in a few more ways. For example,
 Rust traits cannot define data members and cannot define private or protected
 methods. This limits the effectiveness of using traits to implement the template
 method pattern.
@@ -112,7 +112,7 @@ visible as methods on the type.
 Traits can, however, inherit from each other, including multiple inheritance. As
 in modern C++, inheritance hierarchies in Rust tend to be shallow. In situations
 with complex multiple inheritance, however, the diamond problem cannot arise in
-Rust because traits cannot override other traits implementations. Therefore, all
+Rust because traits cannot override other trait implementations. Therefore, all
 paths to a common parent trait resolve to the same implementation.
 
 {{#quiz inheritance_and_reuse.toml}}

--- a/src/idioms/data_modeling/inheritance_and_reuse.md
+++ b/src/idioms/data_modeling/inheritance_and_reuse.md
@@ -33,12 +33,12 @@ class Printer : public Device {
     bool powered = false;
 public:
     void powerOn() override {
-        this.powered = true;
+        this->powered = true;
         std::cout << "Printer is powered on." << std::endl;
     }
 
     void powerOff() override {
-        this.powered = false;
+        this->powered = false;
         std::cout << "Printer is powered off." << std::endl;
     }
 };

--- a/src/idioms/data_modeling/templates.md
+++ b/src/idioms/data_modeling/templates.md
@@ -91,7 +91,7 @@ impl<Label> DirectedGraph<Label> {
 </div>
 
 In the use case demonstrated in the above example, there are few practical
-differences between using C++ template to define a class and using and Rust's
+differences between using a C++ template to define a class and using Rust's
 generics to define a struct. Whenever one would use a template that takes a
 `typename` or `class` parameter in C++, one can instead take a type parameter in
 Rust.
@@ -197,7 +197,7 @@ impl<Label> DirectedGraph<Label> {
     where
         Label: Ord,
     {
-        // Matches the C++, but is not the idomatic
+        // Matches the C++, but is not the idiomatic
         // implementation!
         if self.node_labels.is_empty() {
             None
@@ -390,7 +390,7 @@ because both are part of the type of the produced array.
 
 ## Rust's `Self` type
 
-Within a Rust struct defintion, `impl` block, or `impl` trait block, there is a
+Within a Rust struct definition, `impl` block, or `impl` trait block, there is a
 `Self` type that is in scope. The `Self` type is the type of the class being
 defined with all of the generic type parameters filled in. It can be useful to
 refer to this type especially in cases where there are many parameters that

--- a/src/idioms/encapsulation/private_and_friends.md
+++ b/src/idioms/encapsulation/private_and_friends.md
@@ -110,7 +110,7 @@ class of `BinaryTree`.
 
 In Rust, however, both types can be defined in the same module, and so have
 access to each other's private fields and methods. The module as a whole
-provides a collection of types, methods, and functions that together define a
+provides a collection of types, methods, and functions that together define an
 encapsulated concept.
 
 <div class="comparison">

--- a/src/idioms/encapsulation/private_constructors.md
+++ b/src/idioms/encapsulation/private_constructors.md
@@ -78,7 +78,7 @@ fn main() {
     let carol =
         Person::new("Carol".to_string(), 20);
     // Can match on the public fields, and then
-    // use .. to ignore the remaning ones.
+    // use .. to ignore the remaining ones.
     let Person { name, age, .. } = carol;
 }
 ```
@@ -146,7 +146,7 @@ mod shape {
 use shape::*;
 
 fn main() {
-    // Variant constructor is accesssible despite not being marked pub.
+    // Variant constructor is accessible despite not being marked pub.
     let triangle = Shape::Triangle {
         base: 1.0,
         height: 2.0,
@@ -154,7 +154,7 @@ fn main() {
 
     let circle = Shape::Circle { radius: 1.0 };
 
-    // Fields accessbile despite not being marked pub.
+    // Fields accessible despite not being marked pub.
     match circle {
         Shape::Triangle { base, height } => {
             println!("Triangle: {}, {}", base, height);
@@ -363,7 +363,7 @@ pub enum Shape {
 
 The attribute is more typically used to force clients of a library to include
 the wildcard when matching on the struct fields, making it so that adding
-additional fields to a struct is not breaking change (i.e., that it does not
+additional fields to a struct is not a breaking change (i.e., that it does not
 [require the increase of the major version component when using semantic
 versioning](https://doc.rust-lang.org/cargo/reference/semver.html)).
 

--- a/src/idioms/encapsulation/setters_and_getters.md
+++ b/src/idioms/encapsulation/setters_and_getters.md
@@ -139,7 +139,7 @@ impl Normalized {
 
 A significant limitation that arises from the way that getter methods interact
 with the borrow checker is that it isn't possible to mutably borrow multiple
-elements from an indexed structure like a vector using a methods like
+elements from an indexed structure like a vector using a method like
 `Vec::get_mut`.
 
 The built-in indexed types have several methods for creating split views onto a

--- a/src/idioms/encapsulation/setters_and_getters.md
+++ b/src/idioms/encapsulation/setters_and_getters.md
@@ -119,7 +119,7 @@ fn sqrt_approx_zero(x: f64) -> bool {
 
 impl Normalized {
     pub fn from_vec2(v: Vec2) -> Option<Self> {
-        if sqrt_approx_zero(v.x * v.x + v.y * v.x - 1.0) {
+        if sqrt_approx_zero(v.x * v.x + v.y * v.y - 1.0) {
             Some(Self(v))
         } else {
             None

--- a/src/idioms/exceptions/expected_errors.md
+++ b/src/idioms/exceptions/expected_errors.md
@@ -447,7 +447,7 @@ struct ErrorA : public std::exception {
 void mightThrowA() {}
 
 struct ErrorB : public std::exception {
-  const char *msg = "ErrorA was produced";
+  const char *msg = "ErrorB was produced";
   const char *what() const noexcept override {
     return msg;
   }
@@ -565,7 +565,7 @@ struct ErrorA : public std::exception {
 void mightThrowA() {}
 
 struct ErrorB : public std::exception {
-  const char *msg = "ErrorA was produced";
+  const char *msg = "ErrorB was produced";
   const char *what() const noexcept override {
     return msg;
   }
@@ -645,7 +645,7 @@ struct ErrorA : public std::exception {
 void mightThrowA() {}
 
 struct ErrorB : public std::exception {
-  const char *msg = "ErrorA was produced";
+  const char *msg = "ErrorB was produced";
   const char *what() const noexcept override {
     return msg;
   }

--- a/src/idioms/exceptions/expected_errors.md
+++ b/src/idioms/exceptions/expected_errors.md
@@ -109,7 +109,7 @@ fn main() {
 In C++, the only way to handle exceptions is `catch`. In Rust, all of the
 features for dealing with [tagged
 unions](../data_modeling/tagged_unions.md) can be used with `Result` and
-`Option`. The most approach depends on the intention of the program.
+`Option`. The best approach depends on the intention of the program.
 
 The basic way of handling an error indicated by a `Result` in Rust is by using
 `match`.

--- a/src/idioms/exceptions/expected_errors.md
+++ b/src/idioms/exceptions/expected_errors.md
@@ -480,7 +480,7 @@ impl Display for ErrorA {
 
 impl Error for ErrorA {}
 
-fn might_throw_A() -> Result<(), ErrorA> {
+fn might_throw_a() -> Result<(), ErrorA> {
     Ok(())
 }
 
@@ -498,7 +498,7 @@ impl Display for ErrorB {
 
 impl Error for ErrorB {}
 
-fn might_throw_B() -> Result<(), ErrorB> {
+fn might_throw_b() -> Result<(), ErrorB> {
     Ok(())
 }
 
@@ -537,8 +537,8 @@ impl From<ErrorB> for ErrorAOrB {
 
 fn process() -> Result<(), ErrorAOrB> {
     // the ? operator uses the From instance
-    might_throw_A()?;
-    might_throw_B()?;
+    might_throw_a()?;
+    might_throw_b()?;
     Ok(())
 }
 ```
@@ -586,7 +586,7 @@ use thiserror::Error;
 #[error("ErrorA was produced")]
 struct ErrorA;
 
-fn might_throw_A() -> Result<(), ErrorA> {
+fn might_throw_a() -> Result<(), ErrorA> {
     Ok(())
 }
 
@@ -594,7 +594,7 @@ fn might_throw_A() -> Result<(), ErrorA> {
 #[error("ErrorB was produced")]
 struct ErrorB;
 
-fn might_throw_B() -> Result<(), ErrorB> {
+fn might_throw_b() -> Result<(), ErrorB> {
     Ok(())
 }
 
@@ -607,8 +607,8 @@ enum ErrorAOrB {
 }
 
 fn process() -> Result<(), ErrorAOrB> {
-    might_throw_A()?;
-    might_throw_B()?;
+    might_throw_a()?;
+    might_throw_b()?;
     Ok(())
 }
 ```
@@ -676,7 +676,7 @@ use thiserror::Error;
 #[error("ErrorA was produced")]
 struct ErrorA;
 
-fn might_throw_A() -> Result<(), ErrorA> {
+fn might_throw_a() -> Result<(), ErrorA> {
     Ok(())
 }
 
@@ -684,13 +684,13 @@ fn might_throw_A() -> Result<(), ErrorA> {
 #[error("ErrorB was produced")]
 struct ErrorB;
 
-fn might_throw_B() -> Result<(), ErrorB> {
+fn might_throw_b() -> Result<(), ErrorB> {
     Ok(())
 }
 
 fn process() -> anyhow::Result<()> {
-    might_throw_A()?;
-    might_throw_B()?;
+    might_throw_a()?;
+    might_throw_b()?;
     Ok(())
 }
 

--- a/src/idioms/iterators.md
+++ b/src/idioms/iterators.md
@@ -2,7 +2,7 @@
 
 Rust iterators resemble C++
 [ranges](https://en.cppreference.com/w/cpp/ranges.html) in that they represent
-iterable sequence and can be manipulated similarly to using
+an iterable sequence and can be manipulated similarly to using
 range views. Since C++ ranges are defined using iterators and ranges were only
 introduced in C++20, this chapter compares Rust iterators with both C++
 iterators and with C++ ranges.
@@ -222,7 +222,7 @@ fn main() {
         println!("{}", x);
     }
 
-    // since v was borrowed, not moved, it is still accessiable here.
+    // since v was borrowed, not moved, it is still accessible here.
     println!("{:?}", v);
 
     for x in &mut v {
@@ -230,7 +230,7 @@ fn main() {
         x.push('!');
     }
 
-    // since v was borrowed, not moved, it is still accessiable here.
+    // since v was borrowed, not moved, it is still accessible here.
     // however, the content of v has been modified
     println!("{:?}", v);
 
@@ -351,7 +351,7 @@ fn main() {
 ## Iterator invalidation
 
 In C++, operations sometimes only invalidate some iterators on a value, such as
-the `erase` method on `std::vector` only invaliding iterators to the erased
+the `erase` method on `std::vector` only invalidating iterators to the erased
 element and those after it, but not the ones before it.
 
 In Rust, the fact that iterators borrow the whole iterated value means that no

--- a/src/idioms/null/sentinel_values.md
+++ b/src/idioms/null/sentinel_values.md
@@ -53,7 +53,7 @@ The `Box<T>` type has the same meaning as `std::unique_ptr<T>` in terms of being
 a uniquely owned pointer to some `T` on the heap, but unlike `std::unique_ptr`,
 it cannot be null. Rust's `Option<T>` (which is similar to `std::optional<T>` in
 C++) can represent optional pointers when used in conjunction with `Box<T>`, as
-in `Optional<Box<T>>`. In [those cases (and in some other
+in `Option<Box<T>>`. In [those cases (and in some other
 cases)](../data_modeling/template_specialization.md#niche-optimization) the
 compiler optimizes the representation to be the same size as `Box<T>` by
 leveraging the fact that `Box` cannot be null.

--- a/src/idioms/null/sentinel_values.md
+++ b/src/idioms/null/sentinel_values.md
@@ -1,6 +1,6 @@
 # Sentinel values
 
-Sentinel values are in-band value that indicates a special situation, such as
+Sentinel values are in-band values that indicate a special situation, such as
 having reached the end of valid data in an iterator.
 
 ## `nullptr`

--- a/src/idioms/object_identity.md
+++ b/src/idioms/object_identity.md
@@ -11,8 +11,8 @@ between specific instances of an object that otherwise have the same properties.
 For example, representing a labeled graph where there may be distinct nodes that
 have the same label.
 
-In Rust, some of these cases are not applicable, and others cases are typically
-handled by instead by implementing a synthetic notion of identity for the
+In Rust, some of these cases are not applicable, and other cases are typically
+handled instead by implementing a synthetic notion of identity for the
 values.
 
 ## Overloading copy assignment and equality comparison operators

--- a/src/idioms/object_identity.md
+++ b/src/idioms/object_identity.md
@@ -40,7 +40,7 @@ struct Person
     Person& operator=(const Person& other) {
         // compare object identity first
         if (this != &other) {
-            this.name = other.name;
+            this->name = other.name;
             // copy the other expensive-to-copy fields
         }
 

--- a/src/idioms/overloading.md
+++ b/src/idioms/overloading.md
@@ -119,7 +119,7 @@ fn main() {
 ```
 
 One exception to this is when the methods are all from the same generic trait
-with with different type parameters for the implementations. In that case, if
+with different type parameters for the implementations. In that case, if
 the signature is sufficient to determine which implementation to use, the trait
 does not need to be specified to resolve the method. This is common when using
 the [`From` trait](https://doc.rust-lang.org/std/convert/trait.From.html).
@@ -149,10 +149,10 @@ fn main() {
 
 ## Overloaded operators
 
-In C++ most operators can either be overloaded either with a free-standing
+In C++ most operators can be overloaded either with a free-standing
 function or by providing a method defining the operator on a class.
 
-Rust provides operator via implementation of specific traits. Implementing a
+Rust provides operators via implementation of specific traits. Implementing a
 method of the same name as required by the trait will not make a type usable
 with the operator if the trait is not implemented.
 
@@ -227,7 +227,7 @@ impl std::ops::Add<&Vec2> for &Vec2 {
     }
 }
 
-// If Vec2 weren't so small, it might be desireable to re-use space in the below
+// If Vec2 weren't so small, it might be desirable to re-use space in the below
 // implementations, since they take ownership.
 
 impl std::ops::Add<Vec2> for &Vec2 {

--- a/src/idioms/placement_new.md
+++ b/src/idioms/placement_new.md
@@ -169,12 +169,12 @@ int main() {
   constexpr unsigned int SIZE = 8000000;
   std::unique_ptr b = std::make_unique<
       std::array<unsigned int, SIZE>>();
-  for (std::size_t i; i < SIZE; ++i) {
+  for (std::size_t i = 0; i < SIZE; ++i) {
     (*b)[i] = 42;
   }
 
   // use b so that it isn't optimized away
-  for (std::size_t i; i < SIZE; ++i) {
+  for (std::size_t i = 0; i < SIZE; ++i) {
     std::cout << (*b)[i] << std::endl;
   }
 }

--- a/src/idioms/placement_new.md
+++ b/src/idioms/placement_new.md
@@ -3,7 +3,7 @@
 <div class="warning">
 
 Some of the statements about Rust in this chapter are dependent on the specifics
-of how the compiler optimizes various programs. Unless otherwise state, the
+of how the compiler optimizes various programs. Unless otherwise stated, the
 results presented here are based on rustc 1.87 using the [2024 language
 edition](https://doc.rust-lang.org/edition-guide/introduction.html).
 
@@ -39,7 +39,7 @@ available when using the nightly compiler with [a feature
 flag](https://doc.rust-lang.org/unstable-book/library-features/allocator-api.html).
 The Rust Book has [instructions on how to install the nightly
 toolchain](https://doc.rust-lang.org/book/appendix-07-nightly-rust.html#unstable-features)
-and the The Rust Unstable Book has [instructions on how to use unstable
+and the Rust Unstable Book has [instructions on how to use unstable
 features](https://doc.rust-lang.org/unstable-book/).
 
 For stable Rust, there are libraries that cover many of the uses of allocators.
@@ -246,7 +246,7 @@ fn main() {
 }
 ```
 
-Depending on what is need, this particular use can be generalized.
+Depending on what is needed, this particular use can be generalized.
 
 ```rust
 fn init_with<T, const SIZE: usize>(

--- a/src/idioms/promotions_and_conversions.md
+++ b/src/idioms/promotions_and_conversions.md
@@ -91,7 +91,7 @@ In C++ functions and static member functions are automatically converted to
 function pointers.
 
 Rust performs the same conversion. In addition to functions and members that do
-not take `self` as an argument, constructors (proper constructors) also have
+not take `self` as an argument, tuple struct constructors also have
 function type and can be converted to function pointers. Non-capturing closures
 do not have function type, but can also be converted to function pointers.
 
@@ -285,9 +285,9 @@ fn main() {
 ### `isize` and `usize`
 
 In the Rust standard library the `isize` and `usize` types are used for values
-intended to used be indices (much like `size_t` in C++). However, their use for
+intended to be used as indices (much like `size_t` in C++). However, their use for
 other purposes is usually discouraged in favor of using explicitly sized types
-such as `u32`. This results a situation where values of type `u32` have to be
+such as `u32`. This results in a situation where values of type `u32` have to be
 converted to `usize` for use in indexing, but `Into<usize>` is not implemented
 for `u32`.
 

--- a/src/idioms/promotions_and_conversions.md
+++ b/src/idioms/promotions_and_conversions.md
@@ -99,7 +99,7 @@ do not have function type, but can also be converted to function pointers.
 
 ```cpp
 int twice(int n) {
-  return n * n;
+  return n * 2;
 }
 
 struct MyPair {
@@ -139,7 +139,7 @@ int main() {
 
 ```rust
 fn twice(x: i32) -> i32 {
-    x * x
+    x * 2
 }
 
 struct MyPair(i32, i32);

--- a/src/idioms/promotions_and_conversions.md
+++ b/src/idioms/promotions_and_conversions.md
@@ -152,22 +152,22 @@ impl MyPair {
 
 fn main() {
     // convert a function to a function pointer
-    let twicePtr: fn(i32) -> i32 = twice;
-    let res = twicePtr(5);
+    let twice_ptr: fn(i32) -> i32 = twice;
+    let res = twice_ptr(5);
 
     // convert a constructor to a function pointer
-    let ctorPtr: fn(i32, i32) -> MyPair = MyPair;
-    let pair = ctorPtr(10, 20);
+    let ctor_ptr: fn(i32, i32) -> MyPair = MyPair;
+    let pair = ctor_ptr(10, 20);
 
     // convert a static method to a function
     // pointer
-    let methodPtr: fn() -> MyPair = MyPair::new;
-    let pair2 = methodPtr();
+    let method_ptr: fn() -> MyPair = MyPair::new;
+    let pair2 = method_ptr();
 
     // convert a non-capturing closure to a
     // function pointer
     let closure: fn(i32) -> i32 = |x: i32| x * 5;
-    let closureRes = closure(2);
+    let closure_res = closure(2);
 }
 ```
 

--- a/src/idioms/rtti.md
+++ b/src/idioms/rtti.md
@@ -130,7 +130,7 @@ fn handle_event(e: Event) {
 
 </div>
 
-Even when the a client of the library is needs to be able to define custom
+Even when a client of the library needs to be able to define custom
 events, it is usually possible to make use of an event enum. This is the
 approach taken by the [winit
 crate](https://docs.rs/winit/latest/winit/event/enum.Event.html), which does
@@ -238,14 +238,14 @@ fn handle_event(e: Event<UserEvent>) {
 </div>
 
 When representing events as an enum truly isn't feasible, sometimes double
-dispatch <!-- TODO: link to visitor --> can be used instead. Otherwise it may be
+dispatch ([the visitor pattern](../patterns/visitor.md)) can be used instead. Otherwise it may be
 necessary to use the `Any` trait or to define an `Event` trait that exposes a
-type identifier that an be used for safe downcasting (via `Any`) or unsafe
+type identifier that can be used for safe downcasting (via `Any`) or unsafe
 downcasting behind a safe interface.[^safe-event-handler]
 
 [^safe-event-handler]: Such an interface usually involves providing individual
     event handling functions for specific types, rather than a single large
-    event handling function, so that the underlying implementation can managing
+    event handling function, so that the underlying implementation can manage
     the enforcement of the invariants required to make the casting safe.
 
 ## Library support for reflection via macros

--- a/src/idioms/rvo.md
+++ b/src/idioms/rvo.md
@@ -3,7 +3,7 @@
 <div class="warning">
 
 Some of the statements about Rust in this chapter are dependent on the specifics
-of how the compiler optimizes various programs. Unless otherwise state, the
+of how the compiler optimizes various programs. Unless otherwise stated, the
 results presented here are based on rustc 1.87 using the [2024 language
 edition](https://doc.rust-lang.org/edition-guide/introduction.html) and with
 `-O2` for C++ and `--opt-level=2` for Rust.

--- a/src/idioms/user-defined_conversions.md
+++ b/src/idioms/user-defined_conversions.md
@@ -139,7 +139,7 @@ fn main() {
 
 </div>
 
-Conversion functions are is often used to implement the safe bool pattern in
+Conversion functions are often used to implement the safe bool pattern in
 C++, [which is addressed in a different way in
 Rust](./promotions_and_conversions.md#safe-bools).
 
@@ -332,7 +332,7 @@ Rust does have one kind of user-defined implicit conversion, called [deref
 coercions](https://doc.rust-lang.org/std/ops/trait.Deref.html#deref-coercion),
 provided by the [`Deref`
 trait](https://doc.rust-lang.org/std/ops/trait.Deref.html) and
-[`DerefMut`trait](https://doc.rust-lang.org/std/ops/trait.DerefMut.html). These
+[`DerefMut` trait](https://doc.rust-lang.org/std/ops/trait.DerefMut.html). These
 coercions exist for making pointer-like types more ergonomic to use.
 
 An [example](https://doc.rust-lang.org/book/ch15-02-deref.html) of implementing

--- a/src/patterns/visitor.md
+++ b/src/patterns/visitor.md
@@ -503,7 +503,7 @@ impl Exp for Let {
 // Error for representing expression evaluation
 // errors.
 //
-// Has a lifetime parameter beacause it borrows
+// Has a lifetime parameter because it borrows
 // the name from the expression.
 #[derive(Debug)]
 enum EvalError<'a> {


### PR DESCRIPTION
## Summary

- **Fix 8 code correctness issues**: `this.` → `this->` in C++ examples, uninitialized loop variable (UB), `twice()` computing square instead of double, math error in normalization check, `Optional<Box<T>>` → `Option<Box<T>>`, ErrorB copy-paste error, snake_case violations in Rust examples, and camelCase variable names in Rust code
- **Fix 20+ grammar/spelling errors** across the book: typos ("beacause", "accesssible", "idomatic", "desireable", etc.), missing articles, subject-verb disagreements, duplicated words, and missing prepositions
- **Fix broken empty link** for the Concurrency chapter in SUMMARY.md
- **Clarify confusing wording**: "constructors (proper constructors)" → "tuple struct constructors", and other minor prose improvements

Each fix is in its own atomic commit for easy review.

## Test plan

- [ ] Verify `mdbook build` succeeds without errors
- [ ] Spot-check rendered output for the modified chapters
- [ ] Verify C++ code examples compile (especially `this->` fixes and loop variable initialization)
- [ ] Verify Rust code examples compile (especially `Option<Box<T>>` fix and snake_case renames)

🤖 Generated with [Claude Code](https://claude.com/claude-code)